### PR TITLE
optionally template targetUrl with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,18 @@ If this property does not exist, this plugin will create the deployment as well.
 
 ### targetUrl
 
-The target URL to associate with this status. This URL should contain output to
+The target URL to associate with this status. This URL can be a string or a function.  If you choose a function, the function will get passed the context.  This URL should contain output to
 keep the user updated while the task is running or serve as historical
 information for what happened in the deployment. See the [GitHub docs][4] for
 more info.
 
 *Default:* `null`
+
+```
+targetUrl: 'https://target-url-example.com',
+-- OR --
+targetUrl(context) { `https://target-url-example.com/${context.revisionData.revisionKey}`; },
+```
 
 ### task
 

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = {
 
         var client = context[pluginName]._client;
 
-        return this._updateDeployment.call(this, id, 'success', 'Deployed successfully', client);
+        return this._updateDeployment.call(this, id, 'success', 'Deployed successfully', client, context);
       },
 
       didFail: function(context) {
@@ -107,10 +107,10 @@ module.exports = {
 
         var client = context[pluginName]._client;
 
-        return this._updateDeployment.call(this, id, 'failure', 'Deploy failed', client);
+        return this._updateDeployment.call(this, id, 'failure', 'Deploy failed', client, context);
       },
 
-      _updateDeployment: function(id, state, description, client) {
+      _updateDeployment: function(id, state, description, client, context) {
         var token       = this.readConfig('token');
         var org         = this.readConfig('org');
         var repo        = this.readConfig('repo');
@@ -120,7 +120,7 @@ module.exports = {
           var body = { state: state, description: description };
 
           if (targetUrl) {
-            body.target_url = targetUrl;
+            body.target_url = typeof targetUrl === 'function' ? targetUrl(context) : targetUrl;
           }
 
           var options = {


### PR DESCRIPTION
WIP Pull request. 

@achambers Looking for your feedback / thoughts. Maybe there is a better way to accomplish this. 

My need is to have the targetUrl be templated with the revision information created by `ember-cli-deploy-revision-data` in order to support revisions for pull requests via https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index

Also, should I be pull-requesting this repo: https://github.com/achambers/ember-cli-deploy-github-deployment-status