### PR TITLE
♻️ Switch to using Authorization header for github auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,19 +61,21 @@ module.exports = {
             body.payload = payload;
           }
 
-          var options = {
-            method: 'POST',
-            uri: 'https://api.github.com/repos/' + org + '/' + repo + '/deployments',
-            headers: {
-              'User-Agent': org
-            },
-            body: body,
-            json: true
+          var headers = {
+            'User-Agent': org
           };
 
           if (token) {
-            options.qs = { access_token: token };
+            headers['Authorization'] = 'token ' + token;
           }
+
+          var options = {
+            method: 'POST',
+            uri: 'https://api.github.com/repos/' + org + '/' + repo + '/deployments',
+            headers: headers,
+            body: body,
+            json: true
+          };
 
           promise = client.request(options);
         }
@@ -123,21 +125,21 @@ module.exports = {
             body.target_url = targetUrl;
           }
 
-          var options = {
-
-            method: 'POST',
-            uri: 'https://api.github.com/repos/' + org + '/' + repo + '/deployments/' + id + '/statuses',
-            headers: {
-              'User-Agent': org
-            },
-            body: body,
-            json: true
+          var headers = {
+            'User-Agent': org
           };
 
           if (token) {
-            options.qs = { access_token: token };
+            headers['Authorization'] = 'token ' + token;
           }
 
+          var options = {
+            method: 'POST',
+            uri: 'https://api.github.com/repos/' + org + '/' + repo + '/deployments/' + id + '/statuses',
+            headers: headers,
+            body: body,
+            json: true
+          };
           return client.request(options);
         }
 

--- a/tests/unit/did-deploy-hook-nodetest.js
+++ b/tests/unit/did-deploy-hook-nodetest.js
@@ -57,8 +57,7 @@ describe('Github Deployment Status | didDeploy hook', function() {
         assert.equal(options.uri,'https://api.github.com/repos/foo/bar/deployments/123/statuses');
         assert.equal(options.method, 'POST');
         assert.equal(options.json, true);
-        assert.deepEqual(options.qs, { access_token: 'token' });
-        assert.deepEqual(options.headers, { 'User-Agent': 'foo' });
+        assert.deepEqual(options.headers, { 'User-Agent': 'foo', 'Authorization': 'token token' });
         assert.deepEqual(options.body, {
           state: 'success',
           target_url: 'https://ember-cli-deploy.com',

--- a/tests/unit/did-fail-hook-nodetest.js
+++ b/tests/unit/did-fail-hook-nodetest.js
@@ -57,8 +57,7 @@ describe('Github Deployment Status | didFail hook', function() {
         assert.equal(options.uri,'https://api.github.com/repos/foo/bar/deployments/123/statuses');
         assert.equal(options.method, 'POST');
         assert.equal(options.json, true);
-        assert.deepEqual(options.qs, { access_token: 'token' });
-        assert.deepEqual(options.headers, { 'User-Agent': 'foo' });
+        assert.deepEqual(options.headers, { 'User-Agent': 'foo', 'Authorization': 'token token' });
         assert.deepEqual(options.body, {
           state: 'failure',
           target_url: 'https://ember-cli-deploy.com',

--- a/tests/unit/will-deploy-hook-nodetest.js
+++ b/tests/unit/will-deploy-hook-nodetest.js
@@ -93,8 +93,7 @@ describe('Github Deployment Status | willDeploy hook', function() {
           assert.equal(options.uri,'https://api.github.com/repos/foo/bar/deployments');
           assert.equal(options.method, 'POST');
           assert.equal(options.json, true);
-          assert.deepEqual(options.qs, { access_token: 'token' });
-          assert.deepEqual(options.headers, { 'User-Agent': 'foo' });
+          assert.deepEqual(options.headers, { 'User-Agent': 'foo', 'Authorization': 'token token' });
           assert.deepEqual(options.body, {
             ref: 'baz',
             auto_merge: false,


### PR DESCRIPTION
Using the `access_token` query param is now deprecated. The preferred
approach now is to use the `Authorization` header. More info here:

https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/