### PR TITLE
Enforce dependency on `request`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "ember-cli": "~3.26.1",
     "glob": "^7.1.7",
     "mocha": "^3.1.0",
-    "mocha-jshint": "^2.3.1",
-    "request": "^2.75.0"
+    "mocha-jshint": "^2.3.1"
   },
   "keywords": [
     "ember-addon",
@@ -33,6 +32,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
     "ember-cli-deploy-plugin": "0.2.9",
+    "request": "^2.75.0",
     "request-promise": "^4.2.6"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-github-deployment-status",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An EmberCLI Deploy plugin to update the deployment status of a commit",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
When we activate the `github-deployment-status` plugin during our deployments, we've been getting this error message:

```
### The "request" library is not installed automatically anymore.
### But is a dependency of "request-promise".
### Please install it with:
### npm install request --save
```

I was able to fix this by moving the `request` package from `devDependencies` to `dependencies`.